### PR TITLE
element ref instead of the pair name/type

### DIFF
--- a/implicit.xsd
+++ b/implicit.xsd
@@ -83,15 +83,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -107,9 +107,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice minOccurs="1" maxOccurs="1">
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -139,7 +139,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" />
+								<xs:element ref="scalar" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -169,7 +169,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="vector" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -206,7 +206,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -238,7 +238,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="value" type="CT_ResourceID" />
+								<xs:element name="resourceid" type="CT_ResourceID" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -275,7 +275,7 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="scalarref" type="CT_ScalarRef" minOccurs="3"
+								<xs:element ref="scalarref" minOccurs="3"
 									maxOccurs="3" />
 							</xs:sequence>
 						</xs:complexType>
@@ -283,7 +283,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="vector" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -316,14 +316,14 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
+								<xs:element ref="scalarref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="vector" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -358,14 +358,14 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" minOccurs="3"
+								<xs:element ref="scalar" minOccurs="3"
 									maxOccurs="3" />
 							</xs:sequence>
 						</xs:complexType>
@@ -416,7 +416,7 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="scalarref" type="CT_ScalarRef" minOccurs="16"
+								<xs:element ref="scalarref" minOccurs="16"
 									maxOccurs="16" />
 							</xs:sequence>
 						</xs:complexType>
@@ -424,7 +424,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -461,7 +461,7 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" minOccurs="4"
+								<xs:element ref="vectorref" minOccurs="4"
 									maxOccurs="4" />
 							</xs:sequence>
 						</xs:complexType>
@@ -469,7 +469,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -506,7 +506,7 @@
 					<xs:element name="in" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" minOccurs="4"
+								<xs:element ref="vectorref" minOccurs="4"
 									maxOccurs="4" />
 							</xs:sequence>
 						</xs:complexType>
@@ -514,7 +514,7 @@
 					<xs:element name="out" minOccurs="1" maxOccurs="1">
 						<xs:complexType>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -562,15 +562,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -586,9 +586,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -635,15 +635,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -659,9 +659,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice minOccurs="1" maxOccurs="1">
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -708,15 +708,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -732,9 +732,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice minOccurs="1" maxOccurs="1">
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -778,8 +778,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
+								<xs:element ref="vectorref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -793,7 +793,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" />
+								<xs:element ref="scalar" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -837,8 +837,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
+								<xs:element ref="vectorref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -852,7 +852,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="vector" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -895,8 +895,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:all>
-								<xs:element name="matrixref" type="CT_MatrixRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="matrixref" />
+								<xs:element ref="vectorref" />
 							</xs:all>
 						</xs:complexType>
 					</xs:element>
@@ -910,7 +910,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="vector" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -951,7 +951,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="matrixref" type="CT_MatrixRef" />
+								<xs:element ref="matrixref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -965,7 +965,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -1006,7 +1006,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="matrixref" type="CT_MatrixRef" />
+								<xs:element ref="matrixref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -1020,7 +1020,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="matrix" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -1064,8 +1064,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1079,8 +1079,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1124,8 +1124,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1139,8 +1139,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1184,8 +1184,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1199,8 +1199,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1244,8 +1244,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1259,8 +1259,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1304,8 +1304,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1319,8 +1319,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1364,8 +1364,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1379,8 +1379,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1427,11 +1427,11 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1447,8 +1447,8 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1496,15 +1496,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1520,9 +1520,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1569,15 +1569,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1593,9 +1593,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1641,15 +1641,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1665,9 +1665,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1714,15 +1714,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1738,9 +1738,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1787,15 +1787,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1811,9 +1811,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1860,15 +1860,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1884,9 +1884,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -1932,15 +1932,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -1956,9 +1956,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2002,7 +2002,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:all>
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
 								<xs:element name="resourceref" type="ST_ResourceID" />
 							</xs:all>
 						</xs:complexType>
@@ -2017,7 +2017,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" />
+								<xs:element ref="scalar" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -2061,7 +2061,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:all>
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
 								<xs:element name="resourceref" type="ST_ResourceID" />
 							</xs:all>
 						</xs:complexType>
@@ -2076,7 +2076,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" />
+								<xs:element ref="scalar" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -2119,7 +2119,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="vectorref" type="CT_VectorRef" />
+								<xs:element ref="vectorref" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -2133,7 +2133,7 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:sequence>
-								<xs:element name="scalar" type="CT_Scalar" />
+								<xs:element ref="scalar" />
 							</xs:sequence>
 						</xs:complexType>
 					</xs:element>
@@ -2157,9 +2157,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
-								<xs:element name="matrixref" type="CT_MatrixRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
+								<xs:element ref="matrixref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2173,9 +2173,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2419,15 +2419,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="2" maxOccurs="2" />
 								</xs:sequence>
 							</xs:choice>
@@ -2443,9 +2443,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2495,15 +2495,15 @@
 							</xs:annotation>
 							<xs:choice>
 								<xs:sequence>
-									<xs:element name="scalarref" type="CT_ScalarRef"
+									<xs:element ref="scalarref"
 										minOccurs="4" maxOccurs="4" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="vectorref" type="CT_VectorRef"
+									<xs:element ref="vectorref"
 										minOccurs="4" maxOccurs="4" />
 								</xs:sequence>
 								<xs:sequence>
-									<xs:element name="matrixref" type="CT_MatrixRef"
+									<xs:element ref="matrixref"
 										minOccurs="4" maxOccurs="4" />
 								</xs:sequence>
 							</xs:choice>
@@ -2519,9 +2519,9 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice>
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2798,10 +2798,10 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:choice minOccurs="0" maxOccurs="2147483647">
-			<xs:element name="scalar" type="CT_Scalar" />
-			<xs:element name="vector" type="CT_Vector" />
-			<xs:element name="matrix" type="CT_Matrix" />
-			<xs:element name="resourceid" type="CT_ResourceID" />
+			<xs:element ref="scalar" />
+			<xs:element ref="vector" />
+			<xs:element ref="matrix" />
+			<xs:element ref="resourceid" />
 			<xs:any namespace="##other" processContents="lax" />
 		</xs:choice>
 	</xs:complexType>
@@ -2815,9 +2815,9 @@
 			</xs:documentation>
 		</xs:annotation>
 		<xs:choice minOccurs="1" maxOccurs="2147483647">
-			<xs:element name="scalarref" type="CT_ScalarRef" minOccurs="0" maxOccurs="2147483647" />
-			<xs:element name="vectorref" type="CT_VectorRef" minOccurs="0" maxOccurs="2147483647" />
-			<xs:element name="matrixref" type="CT_MatrixRef" minOccurs="0" maxOccurs="2147483647" />
+			<xs:element ref="scalarref" minOccurs="0" maxOccurs="2147483647" />
+			<xs:element ref="vectorref" minOccurs="0" maxOccurs="2147483647" />
+			<xs:element ref="matrixref" minOccurs="0" maxOccurs="2147483647" />
 			<xs:any namespace="##other" processContents="lax" />
 		</xs:choice>
 	</xs:complexType>
@@ -2825,57 +2825,57 @@
 	<xs:group name="BasicNodeTypes">
 		<xs:choice>
 			<!-- nodes -->
-			<xs:element name="addition" type="CT_Addition" />
-			<xs:element name="subtraction" type="CT_Subtraction" />
-			<xs:element name="multiplication" type="CT_Multiplication" />
-			<xs:element name="division" type="CT_Division" />
-			<xs:element name="constant" type="CT_ConstantScalar" />
-			<xs:element name="constvec" type="CT_ConstantVector" />
-			<xs:element name="constmat" type="CT_ConstantMatrix" />
-			<xs:element name="composevector" type="CT_ComposeVector" />
-			<xs:element name="vectorfromscalar" type="CT_VectorFromScalar" />
-			<xs:element name="decomposevector" type="CT_DecomposeVector" />
-			<xs:element name="composematrix" type="CT_ComposeMatrix" />
-			<xs:element name="matrixfromcolumns" type="CT_MatrixFromColumns" />
-			<xs:element name="matrixfromrows" type="CT_MatrixFromRows" />
-			<xs:element name="dot" type="CT_DotProduct" />
-			<xs:element name="cross" type="CT_CrossProduct" />
-			<xs:element name="matvecmultiplication" type="CT_MatrixVectorMultiplication" />
-			<xs:element name="transpose" type="CT_Transpose" />
-			<xs:element name="inverse" type="CT_Inverse" />
-			<xs:element name="sin" type="CT_Sinus" />
-			<xs:element name="cos" type="CT_Cosinus" />
-			<xs:element name="tan" type="CT_Tan" />
-			<xs:element name="arcsin" type="CT_Arcsin" />
-			<xs:element name="arccos" type="CT_Arccos" />
-			<xs:element name="arctan" type="CT_Arctan" />
-			<xs:element name="arctan2" type="CT_Arctan2" />
-			<xs:element name="min" type="CT_Min" />
-			<xs:element name="max" type="CT_Max" />
-			<xs:element name="abs" type="CT_Abs" />
-			<xs:element name="fmod" type="CT_Fmod" />
-			<xs:element name="pow" type="CT_Pow" />
-			<xs:element name="sqrt" type="CT_Sqrt" />
-			<xs:element name="exp" type="CT_Exp" />
-			<xs:element name="log" type="CT_Log" />
-			<xs:element name="log2" type="CT_Log2" />
-			<xs:element name="log10" type="CT_Log10" />
-			<xs:element name="select" type="CT_Select" />
-			<xs:element name="clamp" type="CT_Clamp" />
-			<xs:element name="cosh" type="CT_Cosh" />
-			<xs:element name="sinh" type="CT_Sinh" />
-			<xs:element name="tanh" type="CT_Tanh" />
-			<xs:element name="round" type="CT_Round" />
-			<xs:element name="ceil" type="CT_Ceil" />
-			<xs:element name="floor" type="CT_Floor" />
-			<xs:element name="sign" type="CT_Sign" />
-			<xs:element name="fract" type="CT_Fract" />
-			<xs:element name="functioncall" type="CT_FunctionCall" />
-			<xs:element name="mesh" type="CT_SignedDistanceToMesh" />
-			<xs:element name="unsignedmesh" type="CT_UnsignedDistanceToMesh" />
-			<xs:element name="length" type="CT_Length" />
-			<xs:element name="resourceid" type="CT_ConstResourceID" />
-			<xs:element name="mod" type="CT_Mod" />
+			<xs:element ref="addition" />
+			<xs:element ref="subtraction" />
+			<xs:element ref="multiplication" />
+			<xs:element ref="division" />
+			<xs:element ref="constant" />
+			<xs:element ref="constvec" />
+			<xs:element ref="constmat" />
+			<xs:element ref="composevector" />
+			<xs:element ref="vectorfromscalar" />
+			<xs:element ref="decomposevector" />
+			<xs:element ref="composematrix" />
+			<xs:element ref="matrixfromcolumns" />
+			<xs:element ref="matrixfromrows"  />
+			<xs:element ref="dot" />
+			<xs:element ref="cross" />
+			<xs:element ref="matvecmultiplication" />
+			<xs:element ref="transpose" />
+			<xs:element ref="inverse" />
+			<xs:element ref="sin" />
+			<xs:element ref="cos" />
+			<xs:element ref="tan" />
+			<xs:element ref="arcsin" />
+			<xs:element ref="arccos" />
+			<xs:element ref="arctan" />
+			<xs:element ref="arctan2" />
+			<xs:element ref="min" />
+			<xs:element ref="max" />
+			<xs:element ref="abs" />
+			<xs:element ref="fmod" />
+			<xs:element ref="pow" />
+			<xs:element ref="sqrt" />
+			<xs:element ref="exp" />
+			<xs:element ref="log" />
+			<xs:element ref="log2" />
+			<xs:element ref="log10" />
+			<xs:element ref="select" />
+			<xs:element ref="clamp" />
+			<xs:element ref="cosh" />
+			<xs:element ref="sinh" />
+			<xs:element ref="tanh" />
+			<xs:element ref="round" />
+			<xs:element ref="ceil" />
+			<xs:element ref="floor" />
+			<xs:element ref="sign" />
+			<xs:element ref="fract" />
+			<xs:element ref="functioncall" />
+			<xs:element ref="mesh" />
+			<xs:element ref="unsignedmesh" />
+			<xs:element ref="length" />
+			<xs:element ref="resourceid" />
+			<xs:element ref="mod" />
 			<xs:any namespace="##other" processContents="lax" />
 		</xs:choice>
 	</xs:group>
@@ -2969,10 +2969,10 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice minOccurs="1" maxOccurs="2147483647">
-								<xs:element name="scalarref" type="CT_ScalarRef" />
-								<xs:element name="vectorref" type="CT_VectorRef" />
-								<xs:element name="matrixref" type="CT_MatrixRef" />
-								<xs:element name="resourceref" type="CT_ResourceRef" />
+								<xs:element ref="scalarref" />
+								<xs:element ref="vectorref" />
+								<xs:element ref="matrixref" />
+								<xs:element ref="resourceref" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -2986,10 +2986,10 @@
 								</xs:documentation>
 							</xs:annotation>
 							<xs:choice minOccurs="1" maxOccurs="2147483647">
-								<xs:element name="scalar" type="CT_Scalar" />
-								<xs:element name="vector" type="CT_Vector" />
-								<xs:element name="matrix" type="CT_Matrix" />
-								<xs:element name="resourceid" type="CT_ResourceID" />
+								<xs:element ref="scalar" />
+								<xs:element ref="vector" />
+								<xs:element ref="matrix" />
+								<xs:element ref="resourceid" />
 							</xs:choice>
 						</xs:complexType>
 					</xs:element>
@@ -3094,12 +3094,16 @@
 	</xs:simpleType>
 
 	<!-- Elements -->
+	<xs:element name="resources" type="CT_Resources" />
+	
 	<xs:element name="implicitfunction" type="CT_ImplicitFunction" />
 	<xs:element name="scalar" type="CT_Scalar" />
 	<xs:element name="vector" type="CT_Vector" />
 	<xs:element name="matrix" type="CT_Matrix" />
 	<xs:element name="resourceid" type="CT_ResourceID" />
-
+	<xs:element name="in" type="CT_Input" />
+	<xs:element name="out" type="CT_Output" />
+	
 	<xs:element name="scalarref" type="CT_ScalarRef" />
 	<xs:element name="vectorref" type="CT_VectorRef" />
 	<xs:element name="matrixref" type="CT_MatrixRef" />


### PR DESCRIPTION
Use directly in elelemts the added element definitions as ref, instead of the pair name/type, which makes the new elements definition unused.

Fixed CT_ConstResourceID to the element name is "indentifier" not "value".